### PR TITLE
Adding workaround for improper comment support for Awk

### DIFF
--- a/plugin/licenses.vim
+++ b/plugin/licenses.vim
@@ -73,6 +73,9 @@ endif
 " Default comment delimiters for some languages without proper options
 " setting.
 let s:filetypeCommentDelimiters = {
+    \'awk': {
+        \'singlelineStart': '# '
+    \},
     \'cmake': {
         \'singlelineStart': '# '
     \},


### PR DESCRIPTION
Sorry about the _absurdly_ long time this took me - I kinda lost track of it. This should fix issue #17, at long last.