### PR TITLE
Add MIT/Apache2 dual license

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,9 @@ Commands
 `:Mit`
     Add the MIT license to the buffer.
 
+`:MitApache`
+    Add the MIT/Apache Licence 2.0 dual license to the buffer.
+
 `:Mpl`
     Add the Mozilla Public License 2.0 to the buffer.
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Commands
 `:Mit`
     Add the MIT license to the buffer.
 
-`:MitApache`
+`:Mitapache`
     Add the MIT/Apache Licence 2.0 dual license to the buffer.
 
 `:Mpl`

--- a/doc/licenses.txt
+++ b/doc/licenses.txt
@@ -83,7 +83,7 @@ Commands:
 :Mit
     Add the MIT license to the buffer.
 
-:MitApache
+:Mitapache
     Add the MIT/Apache Licence 2.0 dual license to the buffer.
 
 :Mpl

--- a/doc/licenses.txt
+++ b/doc/licenses.txt
@@ -83,6 +83,9 @@ Commands:
 :Mit
     Add the MIT license to the buffer.
 
+:MitApache
+    Add the MIT/Apache Licence 2.0 dual license to the buffer.
+
 :Mpl
     Add the Mozilla Public License 2.0 to the buffer.
 

--- a/licenses/mitapache.txt
+++ b/licenses/mitapache.txt
@@ -1,0 +1,38 @@
+Copyright (c) <year> <name of copyright holder>
+<name of author>
+
+Licensed unter the Apache License, Version 2.0 or the MIT license, at your
+option.
+
+********************************************************************************
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+********************************************************************************
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/plugin/licenses.vim
+++ b/plugin/licenses.vim
@@ -62,6 +62,7 @@ if !exists('g:licenses_default_commands')
         \, 'isc'
         \, 'lgpl'
         \, 'mit'
+        \, 'mitapache'
         \, 'mpl'
         \, 'unlicense'
         \, 'verbatim'


### PR DESCRIPTION
Coming from Rust, where many projects are dual licensed under MIT and Apache, I added an dual license file and added it to the defaults.
Also I stumbled across a bug where only the first occurrence of a tag like `<year>` is replaced by the plugin. If the same tag occurs more than once, all except the first occurrence will stay untouched.