### PR TITLE
added uiuc license

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,9 @@ Commands
 `:Mpl`
     Add the Mozilla Public License 2.0 to the buffer.
 
+`:Uiuc`
+    Add the University of Illinois/NCSA Open Source License (UIUC) to the buffer.
+
 `:Unlicense`
     Add the Unlicense to the buffer.
 

--- a/licenses/uiuc.txt
+++ b/licenses/uiuc.txt
@@ -1,0 +1,34 @@
+Copyright (c) <year> <name of copyright holder>
+All rights reserved.
+
+Developed by:
+
+    <NAME OF DEVELOPMENT GROUP>
+    <NAME OF INSTITUTION>
+    <URL FOR DEVELOPMENT GROUP/INSTITUTION>
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal with the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimers.
+
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimers in the
+      documentation and/or other materials provided with the distribution.
+
+    * Neither the names of the copyright holder nor the names of its
+      contributors may be used to endorse or promote products derived from
+      this Software without specific prior written permission.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+THE CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS WITH THE SOFTWARE.

--- a/plugin/licenses.vim
+++ b/plugin/licenses.vim
@@ -64,6 +64,7 @@ if !exists('g:licenses_default_commands')
         \, 'mit'
         \, 'mitapache'
         \, 'mpl'
+        \, 'uiuc'
         \, 'unlicense'
         \, 'verbatim'
         \, 'wtfpl'


### PR DESCRIPTION
the template from wikipedia actually has placeholders in the third bullet point, which I replaced by "the copyright holder" since I saw the plugin only replaces the first occurance of a placeholder and didn't see a quick way to change that.

happy for suggestions.