### PR TITLE
leave #compdef in the first line

### DIFF
--- a/plugin/licenses.vim
+++ b/plugin/licenses.vim
@@ -207,7 +207,7 @@ function! s:insertLicense(licenseFileName, secondLineEmpty)
 
     let line1 = getline(1)
 
-    if line1 =~# '^#!/'
+    if line1 =~# '^#!/' || line1 =~# '^#compdef'
         if line('$') < 2
             normal! o
             call setline('.', '')
@@ -237,7 +237,7 @@ function s:insertSinglelineComment(commentDelimiters, addedLineCount)
     normal! gg
 
     let line1 = getline(1)
-    if line1 =~# '^#!/'
+    if line1 =~# '^#!/' || line1 =~# '^#compdef'
         call cursor(line('.') + 2, 0)
     endif
 


### PR DESCRIPTION
zsh completion files should keep the `#compdef` statement in the first line, just like the common `#!/usr/bin/something`.

The attached patch is not exactly elegant but works for me.